### PR TITLE
fix(api): Only fetch *latest* deployment

### DIFF
--- a/src/api/http/get-project-data.ts
+++ b/src/api/http/get-project-data.ts
@@ -34,13 +34,12 @@ const getProjectData = async (
     })
   })
 
-  // Latest Deployment of each Service in the Project.
-  const deployments: App.Deployment[] = project.services.edges.flatMap((s) => {
-    return s.node.deployments.edges.map((d) => {
+  // Latest Deployment of each Service in all Environments of the Project.
+  const deployments: App.Deployment[] = project.environments.edges.flatMap((e) => {
+    return e.node.deployments.edges.map(d => {
       return {
         id: d.node.id,
         staticUrl: d.node.staticUrl,
-        serviceId: s.node.id,
       }
     })
   })

--- a/src/api/http/queries.ts
+++ b/src/api/http/queries.ts
@@ -14,12 +14,12 @@ const ProjectQuery = gql`
           }
         }
       }
-      services {
+      environments {
         edges {
           node {
             id
             name
-            deployments {
+            deployments(first: 1) {
               edges {
                 node {
                   id
@@ -27,14 +27,6 @@ const ProjectQuery = gql`
                 }
               }
             }
-          }
-        }
-      }
-      environments {
-        edges {
-          node {
-            id
-            name
           }
         }
       }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -34,7 +34,6 @@ export namespace App {
   export interface Deployment {
     id: string
     staticUrl: string
-    serviceId: string
   }
 
   export interface State {
@@ -70,7 +69,7 @@ export namespace QueryResponse {
 
   namespace EdgeResponses {
     export interface Deployments {
-      __typename: 'ServiceDeploymentsConnection'
+      __typename: 'EnvironmentDeploymentsConnection'
       edges: Edge.Deployment[]
     }
 
@@ -82,15 +81,11 @@ export namespace QueryResponse {
       __typename: 'ProjectPluginsConnection'
       edges: Edge.Plugin[]
     }
-    export interface Services {
-      __typename: 'ProjectServicesConnection'
-      edges: Edge.Service[]
-    }
   }
 
   namespace Edge {
     export interface Deployment {
-      __typename: 'ServiceDeploymentsConnectionEdge'
+      __typename: 'EnvironmentDeploymentsConnectionEdge'
       node: Node.Deployment
     }
     export interface Environment {
@@ -100,10 +95,6 @@ export namespace QueryResponse {
     export interface Plugin {
       __typename: 'ProjectPluginsConnectionEdge'
       node: Node.Plugin
-    }
-    export interface Service {
-      __typename: 'ProjectServicesConnectionEdge'
-      node: Node.Service
     }
   }
 
@@ -118,6 +109,7 @@ export namespace QueryResponse {
       __typename: 'Environment'
       id: string
       name: string
+      deployments: EdgeResponses.Deployments
     }
 
     export interface Project {
@@ -125,7 +117,6 @@ export namespace QueryResponse {
       id: string
       name: string
       plugins: EdgeResponses.Plugins
-      services: EdgeResponses.Services
       environments: EdgeResponses.Environments
     }
 
@@ -133,13 +124,6 @@ export namespace QueryResponse {
       __typename: 'Plugin'
       id: string
       name: string
-    }
-
-    export interface Service {
-      __typename: 'Service'
-      id: string
-      name: string
-      deployments: EdgeResponses.Deployments
     }
   }
 }


### PR DESCRIPTION
This changes the GQL calls to traverse from environments->deployments, instead of services->deployments. I made a mistake assuming that only the latest deployment is returned by default.