### PR TITLE
feat(*): Add better error handling

### DIFF
--- a/src/api/http/client.ts
+++ b/src/api/http/client.ts
@@ -1,16 +1,40 @@
 import { HttpClient } from '@/types'
-import { ApolloClient, InMemoryCache } from '@apollo/client/core'
+import {
+  ApolloClient,
+  ApolloLink,
+  HttpLink,
+  InMemoryCache,
+} from '@apollo/client/core'
+import { RetryLink } from '@apollo/client/link/retry'
 
 /**
  * Creates an authenticated GQL HTTP client.
  */
 const createHttpClient = (endpoint: string, apiToken: string): HttpClient => {
-  return new ApolloClient({
+  const httpLink = new HttpLink({
     uri: endpoint,
-    cache: new InMemoryCache(),
     headers: {
       Authorization: `Bearer ${apiToken}`,
     },
+  })
+
+  const retryLink = new RetryLink({
+    delay: {
+      initial: 300,
+      max: Infinity,
+      jitter: true,
+    },
+    attempts: {
+      max: 5,
+      retryIf: (error, _operation) => !!error,
+    },
+  })
+
+  const link = ApolloLink.from([retryLink, httpLink])
+
+  return new ApolloClient({
+    cache: new InMemoryCache(),
+    link,
   })
 }
 


### PR DESCRIPTION
Resolves #19 by adding retry logic to the HTTP client, and runs the WS handlers inside a retry loop.

While not a truly ideal solution, the goal of this is to clean up the "panic on error" logic to fix constant crashes. I'm also not sure how granular I want error handling to be right now and given the http/ws split here, it's best to just re-visit when stuff isn't crashing.

On another note, the Railway API is erroring out super frequently (504s on HTTP, 5xx-es on WS routes)..